### PR TITLE
Fixing misleading details about tab selection api

### DIFF
--- a/jade/page-contents/tabs_content.html
+++ b/jade/page-contents/tabs_content.html
@@ -55,7 +55,7 @@
 
       <div id="method" class="section scrollspy">
         <h4>jQuery Plugin Methods</h4>
-        <p>You can programmatically trigger a tab change with our <code class="language-javascript">select_tab</code> method. You have to input the id of the tab you want to switch to. In the case of our demo it would be either test1, test2, test3, or test4.</p>
+        <p>You can programmatically trigger a tab change with our <code class="language-javascript">select_tab</code> method. You have to input the contents of the <code>href</code> of the tab you want to switch to. In the case of our demo it would be either test1, test2, test3, or test4.</p>
         <pre><code class="language-javascript">
   $(document).ready(function(){
     $('ul.tabs').tabs('select_tab', 'tab_id');


### PR DESCRIPTION
Currently, [documentation on tabs](http://materializecss.com/tabs.html) says:

> You can programmatically trigger a tab change with our select_tab method. You have to input the **_id**_ of the tab you want to switch to.   

Specifically:

> input the **_id**_ of the tab

This is very false. [As you can see by the source here, selection of tabs has nothing to do with their id, and is instead entirely based on the contents of the `href` attribute of the element.](https://github.com/Dogfalo/materialize/blob/1f27f1162d0187c905bbb883bff15cf1e5e16a8f/js/tabs.js#L111)

I've updated the documentation here to be correct.
